### PR TITLE
Add GitHub Actions workflow for uploading to PyPI

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -1,0 +1,33 @@
+name: Upload Python Package
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build package
+      run: python setup.py sdist bdist_wheel
+
+    - name: Upload package to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='easy_db',
-    version='0.1.0',
+    version='0.1.1',
     author='Shubham Akshit',
     author_email='akshitshubhammas@gmail.com',
     description='A simple database management package',
@@ -12,6 +12,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pymongo',
+        'twine',
     ],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Add GitHub Actions workflow for uploading to PyPI.

* **setup.py**
  - Update the version to `0.1.1`.
  - Add `twine` to the `install_requires` list.

* **.github/workflows/upload-to-pypi.yml**
  - Create a new GitHub Actions workflow file.
  - Set the workflow to trigger on push to the `main` branch.
  - Add steps to set up Python, install dependencies, build the package, and upload to PyPI.
  - Use `PYPI_USERNAME` and `PYPI_PASSWORD` secrets for authentication.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shubhamakshit/easy_db/pull/2?shareId=baef5105-fc7f-4d32-aebf-592abee184a9).